### PR TITLE
Only default the mtime to "now" for unrecognized images rather than old

### DIFF
--- a/lib/docker-event-stream.coffee
+++ b/lib/docker-event-stream.coffee
@@ -17,12 +17,8 @@ exports.parseEventStream = parseEventStream = (docker) ->
 		# If we've never seen the layer used then it's likely created before we started
 		# listening and so set the last used time to 0 as we know it should be older than
 		# anything we've seen
-		#
-		# Disable this behaviour for local testing, otherwise the GC will try to remove already
-		# existing images and the tests will break
-		if ! process.env.LOCAL_TESTS
-			for image in images
-				layer_mtimes[image.Id] = 0
+		for image in images
+			layer_mtimes[image.Id] = 0
 
 		return es.pipeline(
 			JSONStream.parse()

--- a/lib/docker-image-tree.coffee
+++ b/lib/docker-image-tree.coffee
@@ -37,7 +37,9 @@ exports.createTree = createTree = (images, containers, layer_mtimes) ->
 		node.repoTags = saneRepoAttrs(image.RepoTags)
 		node.repoDigests = saneRepoAttrs(image.RepoDigests)
 		node.size = image.Size
-		node.mtime = getMtime(node, layer_mtimes) or now
+		# If we haven't seen the image at all then assume it is brand new and default it's
+		# mtime to `now` to avoid removing it
+		node.mtime = getMtime(node, layer_mtimes) ? now
 		node.isUsedByAContainer = usedImageIds.has(image.Id)
 		parent.children[image.Id] = node
 

--- a/lib/docker.coffee
+++ b/lib/docker.coffee
@@ -6,28 +6,9 @@ fs = require 'mz/fs'
 url = require 'url'
 
 getDockerConnectOpts = (hostObj) ->
-
-	return Promise.resolve(hostObj) if !_.isEmpty(hostObj)
-
-	# Detect circleCi build
-	if process.env.CIRCLECI?
-		certs = ['ca.pem', 'cert.pem', 'key.pem'].map((file) -> path.join(process.env.DOCKER_CERT_PATH, file))
-
-		Promise.map(certs, (c) -> fs.readFile(c, 'utf-8'))
-		.then ([ca, cert, key]) ->
-
-			parsed = url.parse(process.env.DOCKER_HOST)
-
-			return {
-				host: 'https://' + parsed.hostname
-				port: parsed.port
-				ca
-				cert
-				key
-				Promise
-			}
-	else
-		return Promise.resolve({ socketPath: '/var/run/docker.sock', Promise })
+	if !_.isEmpty(hostObj)
+		return Promise.resolve(hostObj)
+	return Promise.resolve({ socketPath: '/var/run/docker.sock', Promise })
 
 exports.getDocker = (hostObj) ->
 	getDockerConnectOpts(hostObj)

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "types": "index.d.ts",
   "scripts": {
     "lint": "resin-lint lib test tools",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && docker rm -vf docker-storage-gc-tests && docker run --privileged --name docker-storage-gc-tests -v /tmp/dind:/var/run/ -d docker:24.0.5-dind && sleep 5 && docker exec docker-storage-gc-tests chown $(id -u) /var/run/docker.sock",
     "test": "mocha --compilers coffee:coffee-script/register test",
-    "test:local": "LOCAL_TESTS=true npm test",
+    "posttest": "docker rm -vf docker-storage-gc-tests",
     "prepare": "coffee -o build -c lib"
   },
   "author": "",

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -32,8 +32,14 @@ describe 'Garbage collection', ->
 		@dockerStorage = new DockerGC()
 		# Use either local or CI docker
 		Promise.join(
-			dockerUtils.getDocker({})
-			@dockerStorage.setDocker({})
+			dockerUtils.getDocker({
+				socketPath: '/tmp/dind/docker.sock',
+				Promise,
+			})
+			@dockerStorage.setDocker({
+				socketPath: '/tmp/dind/docker.sock',
+				Promise,
+			})
 			(docker) =>
 				@dockerStorage.setupMtimeStream()
 				@docker = docker

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -57,7 +57,7 @@ describe 'Garbage collection', ->
 		.then ->
 			dockerStorage.garbageCollect(1)
 		.then ->
-			promiseToBool(docker.getImage(NONE_TAG_IMAGES[0]).inspect())
+			promiseToBool(docker.getImage(IMAGES[0]).inspect())
 		.then (image_found) ->
 			expect(image_found).to.be.false
 
@@ -68,7 +68,7 @@ describe 'Garbage collection', ->
 
 		pullAsync(docker, NONE_TAG_IMAGES[0])
 		.then ->
-			docker.getImage(NONE_TAG_IMAGES[0])	.inspect()
+			docker.getImage(NONE_TAG_IMAGES[0]).inspect()
 		.then ->
 			dockerStorage.garbageCollect(1)
 		.then ->
@@ -84,7 +84,7 @@ describe 'Garbage collection', ->
 		Promise.each NONE_TAG_IMAGES, (image) ->
 			pullAsync(docker, image)
 		.then ->
-			docker.getImage(NONE_TAG_IMAGES[0])	.inspect()
+			docker.getImage(NONE_TAG_IMAGES[0]).inspect()
 		.then ->
 			dockerStorage.garbageCollect(1)
 		.then ->


### PR DESCRIPTION
This avoids issues where images that existed before the garbage
collector was attached would always have their mtime set to "now" and
be avoided for removal. Instead we now only do it for images we haven't
seen which should only be the case for newly added images which haven't
yet had an mtime added but shortly will do, in which case `now` is a
good approximation

Change-type: patch