### PR TITLE
Use partial updates for rebuilding the removal candidate list

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -70,8 +70,8 @@ const getImagesToRemove = function (
 	const leafs = getUnusedTreeLeafs(tree);
 	const resort = () => {
 		leafs.sort((a, b) => {
-			// mtime asc, size desc
-			return mtimeSort(a, b) || -sizeSort(a, b);
+			// mtime desc, size asc
+			return -mtimeSort(a, b) || sizeSort(a, b);
 		});
 	};
 	resort();
@@ -79,7 +79,7 @@ const getImagesToRemove = function (
 		if (leafs.length === 0) {
 			break;
 		}
-		const leaf = leafs.shift()!;
+		const leaf = leafs.pop()!;
 		if (leaf !== tree) {
 			// don't remove the tree root
 			result.push(leaf);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache 2.0",
   "description": "Automatically cleanup unused images based on various cache replacement algorithms",
   "dependencies": {
-    "@types/dockerode": "^3.3.24",
+    "@types/dockerode": "3.3.24",
     "@types/event-stream": "^4.0.5",
     "@types/JSONStream": "npm:@types/jsonstream@^0.8.33",
     "@types/node": "^16.18.87",


### PR DESCRIPTION
This means that we now check only the parent of the node we're removing to see if it is now a valid candidate and can avoid rebuilding, and sorting, the full list from scratch every time. This removes significant work in rebuilding/sorting the list on every iteration and also reduces allocations/garbage collection overhead related to that

Change-type: minor