### PR TITLE
Fix getMtime resolution across ID and tag keys

### DIFF
--- a/lib/docker-event-stream.ts
+++ b/lib/docker-event-stream.ts
@@ -26,7 +26,7 @@ const CONTAINER_EVENTS = [
 	'unpause',
 ];
 
-export type LayerMtimes = Map<string, string | number | undefined>;
+export type LayerMtimes = Map<string, number>;
 
 interface DockerEvent {
 	status: string;
@@ -89,15 +89,15 @@ export const parseEventStream = async (
 			objectMode: true,
 			transform(evt: DockerEvent, _encoding, cb) {
 				try {
-					const { status, id, from, timeNano } = evt;
+					const { status, id, from, time } = evt;
 					if (IMAGE_EVENTS.includes(status)) {
 						if (status === 'delete') {
 							layerMtimes.delete(id);
 						} else {
-							layerMtimes.set(id, timeNano);
+							layerMtimes.set(id, time);
 						}
 					} else if (CONTAINER_EVENTS.includes(status)) {
-						layerMtimes.set(from, timeNano);
+						layerMtimes.set(from, time);
 					}
 					cb(null, layerMtimes);
 				} catch (err: any) {

--- a/lib/docker-image-tree.ts
+++ b/lib/docker-image-tree.ts
@@ -24,21 +24,23 @@ export const createNode = (id: string): ImageNode => ({
 	children: {},
 });
 
-const getMtimeFrom = function (layerMtimes: LayerMtimes, attributes: string[]) {
-	for (const key of attributes) {
-		const mtime = layerMtimes.get(key);
-		if (mtime != null) {
-			return mtime;
+const getMtime = function (tree: ImageNode, layerMtimes: LayerMtimes) {
+	// Collect mtime candidates from all possible keys (ID, tags, digests).
+	// Container events store mtime under the `from` field which may be a tag,
+	// while stream init stores 0 under the sha256 ID. We need the most recent
+	// value across all keys to avoid treating a recently-used image as stale.
+	let max: number | undefined;
+	const keys = [tree.id, ...tree.repoTags, ...tree.repoDigests];
+	for (const key of keys) {
+		const val = layerMtimes.get(key);
+		if (val != null) {
+			const num = typeof val === 'string' ? Number(val) : val;
+			if (!Number.isNaN(num) && (max == null || num > max)) {
+				max = num;
+			}
 		}
 	}
-};
-
-const getMtime = function (tree: ImageNode, layerMtimes: LayerMtimes) {
-	return (
-		layerMtimes.get(tree.id) ??
-		getMtimeFrom(layerMtimes, tree.repoTags) ??
-		getMtimeFrom(layerMtimes, tree.repoDigests)
-	);
+	return max;
 };
 
 export interface ImageNode {

--- a/lib/docker-image-tree.ts
+++ b/lib/docker-image-tree.ts
@@ -33,11 +33,8 @@ const getMtime = function (tree: ImageNode, layerMtimes: LayerMtimes) {
 	const keys = [tree.id, ...tree.repoTags, ...tree.repoDigests];
 	for (const key of keys) {
 		const val = layerMtimes.get(key);
-		if (val != null) {
-			const num = typeof val === 'string' ? Number(val) : val;
-			if (!Number.isNaN(num) && (max == null || num > max)) {
-				max = num;
-			}
+		if (val != null && (max == null || val > max)) {
+			max = val;
 		}
 	}
 	return max;
@@ -58,7 +55,7 @@ export const createTree = function (
 	containers: Docker.ContainerInfo[],
 	layerMtimes: LayerMtimes,
 ): ImageNode {
-	const now = Date.now() * Math.pow(10, 6); // convert to nanoseconds
+	const now = Math.floor(Date.now() / 1000); // unix seconds, matching Docker event `time` field
 	const usedImageIds = new Set(containers.map((c) => c.ImageID));
 	const tree: {
 		[key: string]: ImageNode;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -82,6 +82,7 @@ const getImagesToRemove = function (
 			break;
 		}
 		const leaf = leafs.pop()!;
+		leaf.removed = true;
 		if (leaf !== tree) {
 			// don't remove the tree root
 			result.push(leaf);
@@ -92,7 +93,6 @@ const getImagesToRemove = function (
 				resort();
 			}
 		}
-		leaf.removed = true;
 	}
 
 	metrics.emit('numberImagesToRemove', result.length);

--- a/test/docker-event-stream.ts
+++ b/test/docker-event-stream.ts
@@ -12,34 +12,50 @@ import fixtureImages from './fixtures/docker-images.json';
 const createMockDocker = (imageList = fixtureImages) =>
 	({ listImages: () => Promise.resolve(imageList) }) as Dockerode;
 
+const pipeEvents = async (events: object[]): Promise<LayerMtimes> => {
+	const streamParsers = await parseEventStream(docker);
+	let mtimes: LayerMtimes = new Map();
+	const input = new Stream.Readable({
+		read() {
+			for (const evt of events) {
+				this.push(JSON.stringify(evt) + '\n');
+			}
+			this.push(null);
+		},
+	});
+	await Stream.promises.pipeline(
+		input,
+		...streamParsers,
+		new Stream.Transform({
+			objectMode: true,
+			transform(data: LayerMtimes, _encoding, cb) {
+				mtimes = data;
+				cb();
+			},
+		}),
+	);
+	return mtimes;
+};
+
 describe('parseEventStream', function () {
 	it.skip('should work with empty stream', function () {
 		// TODO
 	});
 
 	it('should return updated mtimes', async () => {
-		const streamParsers = await parseEventStream(docker);
-
-		let mtimes: LayerMtimes;
-		await Stream.promises.pipeline(
-			fs.createReadStream(__dirname + '/fixtures/docker-events.json'),
-			...streamParsers,
-			new Stream.Transform({
-				objectMode: true,
-				transform($data: LayerMtimes, _encoding, cb) {
-					mtimes = $data;
-					cb();
-				},
-			}),
-		);
-		expect(mtimes!.get('busybox:latest')).to.equal(1448576072937294800);
+		const lines = fs
+			.readFileSync(__dirname + '/fixtures/docker-events.json', 'utf8')
+			.trim()
+			.split('\n');
+		const mtimes = await pipeEvents(lines.map((line) => JSON.parse(line)));
+		expect(mtimes.get('busybox:latest')).to.equal(1448576072937294800);
 		expect(
-			mtimes!.get(
+			mtimes.get(
 				'sha256:6d41a4a0bf8168363e29da8a5ecbf3cd6c37e3f5a043decd5e7da6e427ba869c',
 			),
 		).to.equal(1448576073085559800);
 		expect(
-			mtimes!.get(
+			mtimes.get(
 				'sha256:9a61b6b1315e6b457c31a03346ab94486a2f5397f4a82219bee01eead1c34c2e',
 			),
 		).to.equal(1448576073203895800);
@@ -92,5 +108,31 @@ describe('parseEventStream mtime persistence', function () {
 		const layerMtimes = new Map([[key, 1234567890]]);
 		await parseEventStream(createMockDocker(), layerMtimes);
 		expect(layerMtimes.has(key)).to.eq(false);
+	});
+
+	it('should store container event mtime under the from key', async () => {
+		const mtimes = await pipeEvents([
+			{
+				status: 'create',
+				id: 'container1',
+				from: 'myapp:latest',
+				time: 1700000000,
+				timeNano: 1700000000000000000,
+			},
+		]);
+		expect(mtimes.get('myapp:latest')).to.equal(1700000000000000000);
+	});
+
+	it('should store container event mtime under sha256 ID when from is an ID', async () => {
+		const mtimes = await pipeEvents([
+			{
+				status: 'start',
+				id: 'container1',
+				from: 'sha256:abc123def456',
+				time: 1700000000,
+				timeNano: 1700000000000000000,
+			},
+		]);
+		expect(mtimes.get('sha256:abc123def456')).to.equal(1700000000000000000);
 	});
 });

--- a/test/docker-event-stream.ts
+++ b/test/docker-event-stream.ts
@@ -43,22 +43,26 @@ describe('parseEventStream', function () {
 	});
 
 	it('should return updated mtimes', async () => {
-		const lines = fs
-			.readFileSync(__dirname + '/fixtures/docker-events.json', 'utf8')
+		const lines = (
+			await fs.promises.readFile(
+				__dirname + '/fixtures/docker-events.json',
+				'utf8',
+			)
+		)
 			.trim()
 			.split('\n');
 		const mtimes = await pipeEvents(lines.map((line) => JSON.parse(line)));
-		expect(mtimes.get('busybox:latest')).to.equal(1448576072937294800);
+		expect(mtimes.get('busybox:latest')).to.equal(1448576072);
 		expect(
 			mtimes.get(
 				'sha256:6d41a4a0bf8168363e29da8a5ecbf3cd6c37e3f5a043decd5e7da6e427ba869c',
 			),
-		).to.equal(1448576073085559800);
+		).to.equal(1448576073);
 		expect(
 			mtimes.get(
 				'sha256:9a61b6b1315e6b457c31a03346ab94486a2f5397f4a82219bee01eead1c34c2e',
 			),
-		).to.equal(1448576073203895800);
+		).to.equal(1448576073);
 	});
 });
 
@@ -117,10 +121,9 @@ describe('parseEventStream mtime persistence', function () {
 				id: 'container1',
 				from: 'myapp:latest',
 				time: 1700000000,
-				timeNano: 1700000000000000000,
 			},
 		]);
-		expect(mtimes.get('myapp:latest')).to.equal(1700000000000000000);
+		expect(mtimes.get('myapp:latest')).to.equal(1700000000);
 	});
 
 	it('should store container event mtime under sha256 ID when from is an ID', async () => {
@@ -130,9 +133,8 @@ describe('parseEventStream mtime persistence', function () {
 				id: 'container1',
 				from: 'sha256:abc123def456',
 				time: 1700000000,
-				timeNano: 1700000000000000000,
 			},
 		]);
-		expect(mtimes.get('sha256:abc123def456')).to.equal(1700000000000000000);
+		expect(mtimes.get('sha256:abc123def456')).to.equal(1700000000);
 	});
 });

--- a/test/docker-image-tree.ts
+++ b/test/docker-image-tree.ts
@@ -6,7 +6,9 @@ import { Stream } from 'node:stream';
 import type { LayerMtimes } from '../build/docker-event-stream';
 import { parseEventStream } from '../build/docker-event-stream';
 import { createTree } from '../build/docker-image-tree';
-import { docker } from './lib/common';
+import { docker, makeContainer, makeImage } from './lib/common';
+
+const FROZEN_DATE = Date.UTC(2016, 0, 1);
 
 const getLayerMtimes = async () => {
 	const streamParsers = await parseEventStream(docker);
@@ -43,7 +45,7 @@ describe('createTree', function () {
 			})
 		).default as ContainerInfo[];
 		const mtimes = await getLayerMtimes();
-		tk.freeze(Date.UTC(2016, 0, 1));
+		tk.freeze(FROZEN_DATE);
 		const tree = createTree(images, containers, mtimes);
 		tk.reset();
 		const output = {
@@ -135,5 +137,110 @@ describe('createTree', function () {
 			},
 		};
 		expect(tree).to.deep.equal(output);
+	});
+
+	describe('mtime resolution', function () {
+		it('should resolve mtime from repoTags when ID key is 0', function () {
+			const recentTime = 1700000000000000000;
+			const images: ImageInfo[] = [
+				makeImage('sha256:img1', '', { tags: ['myapp:latest'] }),
+			];
+			const mtimes: LayerMtimes = new Map<string, string | number>([
+				['sha256:img1', 0], // set by parseEventStream init
+				['myapp:latest', recentTime], // set by container event with from=tag
+			]);
+
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], mtimes);
+			tk.reset();
+
+			// Should resolve to the tag-keyed mtime, not the ID-keyed 0
+			expect(tree.children['sha256:img1'].mtime).to.equal(recentTime);
+		});
+
+		it('should resolve mtime from repoDigests when ID key is 0', function () {
+			const recentTime = 1700000000000000000;
+			const digest =
+				'sha256:a8cf7ff6367c2afa2a90acd081b484cbded349a7076e7bdf37a05279f276bc12';
+			const images: ImageInfo[] = [
+				makeImage('sha256:img1', '', { digests: [digest] }),
+			];
+			const mtimes: LayerMtimes = new Map<string, string | number>([
+				['sha256:img1', 0],
+				[digest, recentTime],
+			]);
+
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], mtimes);
+			tk.reset();
+
+			expect(tree.children['sha256:img1'].mtime).to.equal(recentTime);
+		});
+
+		it('should prefer most recent mtime when ID and tag are both non-zero', function () {
+			const idTime = 1700000000000000000;
+			const tagTime = 1600000000000000000;
+			const images: ImageInfo[] = [
+				makeImage('sha256:img1', '', { tags: ['myapp:latest'] }),
+			];
+			const mtimes: LayerMtimes = new Map<string, string | number>([
+				['sha256:img1', idTime],
+				['myapp:latest', tagTime],
+			]);
+
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], mtimes);
+			tk.reset();
+
+			expect(tree.children['sha256:img1'].mtime).to.equal(idTime);
+		});
+
+		it('should default to now for images not in layerMtimes', function () {
+			const images: ImageInfo[] = [
+				makeImage('sha256:new-image', '', { tags: ['justbuilt:v1'] }),
+			];
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], new Map());
+			tk.reset();
+
+			const expectedNow = FROZEN_DATE * 1e6;
+			expect(tree.children['sha256:new-image'].mtime).to.equal(expectedNow);
+		});
+
+		it('should treat mtime=0 as old, not default to current time', function () {
+			const images: ImageInfo[] = [
+				makeImage('sha256:old', '', { tags: ['old:v1'] }),
+			];
+			const mtimes: LayerMtimes = new Map([['sha256:old', 0]]);
+
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], mtimes);
+			tk.reset();
+
+			expect(tree.children['sha256:old'].mtime).to.equal(0);
+		});
+	});
+
+	describe('isUsedByAContainer', function () {
+		it('should only check direct ImageID, not ancestor images', function () {
+			// A container's image is protected, but its parent/base is not
+			// directly marked — protection comes from tree structure instead
+			const images: ImageInfo[] = [
+				makeImage('sha256:base', '', { tags: ['ubuntu:20.04'] }),
+				makeImage('sha256:child', 'sha256:base', {
+					tags: ['myapp:v1'],
+				}),
+			];
+			const containers: ContainerInfo[] = [makeContainer('sha256:child')];
+			const mtimes: LayerMtimes = new Map();
+
+			const tree = createTree(images, containers, mtimes);
+
+			const base = tree.children['sha256:base'];
+			const child = base.children['sha256:child'];
+			expect(child.isUsedByAContainer).to.be.true;
+			// Base is NOT directly marked — relies on tree structure for protection
+			expect(base.isUsedByAContainer).to.be.false;
+		});
 	});
 });

--- a/test/docker-image-tree.ts
+++ b/test/docker-image-tree.ts
@@ -53,7 +53,7 @@ describe('createTree', function () {
 			size: 0,
 			repoTags: [],
 			repoDigests: [],
-			mtime: 1451606400000000000,
+			mtime: 1451606400,
 			isUsedByAContainer: false,
 			children: {
 				'sha256:6d15899cef812e2876b9d5d43d4cd863eda7b278f7b52d00975f6a9a8e817c74':
@@ -62,7 +62,7 @@ describe('createTree', function () {
 						size: 125151141,
 						repoTags: [],
 						repoDigests: [],
-						mtime: 1451606400000000000,
+						mtime: 1451606400,
 						isUsedByAContainer: false,
 						children: {
 							'sha256:e53bd4df04f86919156c4510cdc6e6c9491ec8ec226381d36aca573b46bbbbbc':
@@ -71,7 +71,7 @@ describe('createTree', function () {
 									size: 0,
 									repoTags: ['project1'],
 									repoDigests: [],
-									mtime: 1451606400000000000,
+									mtime: 1451606400,
 									isUsedByAContainer: false,
 									children: {
 										'sha256:6d41a4a0bf8168363e29da8a5ecbf3cd6c37e3f5a043decd5e7da6e427ba869c':
@@ -80,9 +80,7 @@ describe('createTree', function () {
 												size: 330389,
 												repoTags: ['project2'],
 												repoDigests: [],
-
-												// eslint-disable-next-line no-loss-of-precision
-												mtime: 1448576073085559863,
+												mtime: 1448576073,
 												isUsedByAContainer: false,
 												children: {
 													'sha256:80dc79d29cd8618e678da508fc32f7289e6f72defb534f3f287731b1f8b355ea':
@@ -91,7 +89,7 @@ describe('createTree', function () {
 															size: 98872,
 															repoTags: [],
 															repoDigests: [],
-															mtime: 1451606400000000000,
+															mtime: 1451606400,
 															isUsedByAContainer: false,
 															children: {},
 														},
@@ -107,7 +105,7 @@ describe('createTree', function () {
 						size: 125151141,
 						repoTags: [],
 						repoDigests: [],
-						mtime: 1451606400000000000,
+						mtime: 1451606400,
 						isUsedByAContainer: false,
 						children: {
 							'sha256:9a61b6b1315e6b457c31a03346ab94486a2f5397f4a82219bee01eead1c34c2e':
@@ -116,7 +114,7 @@ describe('createTree', function () {
 									size: 0,
 									repoTags: ['resin/project3'],
 									repoDigests: [],
-									mtime: 1448576073203895800,
+									mtime: 1448576073,
 									isUsedByAContainer: false,
 									children: {},
 								},
@@ -130,7 +128,7 @@ describe('createTree', function () {
 						repoDigests: [
 							'sha256:a8cf7ff6367c2afa2a90acd081b484cbded349a7076e7bdf37a05279f276bc12',
 						],
-						mtime: 1448576072937294800,
+						mtime: 1448576072,
 						isUsedByAContainer: true,
 						children: {},
 					},
@@ -141,11 +139,11 @@ describe('createTree', function () {
 
 	describe('mtime resolution', function () {
 		it('should resolve mtime from repoTags when ID key is 0', function () {
-			const recentTime = 1700000000000000000;
+			const recentTime = 1700000000;
 			const images: ImageInfo[] = [
 				makeImage('sha256:img1', '', { tags: ['myapp:latest'] }),
 			];
-			const mtimes: LayerMtimes = new Map<string, string | number>([
+			const mtimes: LayerMtimes = new Map([
 				['sha256:img1', 0], // set by parseEventStream init
 				['myapp:latest', recentTime], // set by container event with from=tag
 			]);
@@ -159,13 +157,13 @@ describe('createTree', function () {
 		});
 
 		it('should resolve mtime from repoDigests when ID key is 0', function () {
-			const recentTime = 1700000000000000000;
+			const recentTime = 1700000000;
 			const digest =
 				'sha256:a8cf7ff6367c2afa2a90acd081b484cbded349a7076e7bdf37a05279f276bc12';
 			const images: ImageInfo[] = [
 				makeImage('sha256:img1', '', { digests: [digest] }),
 			];
-			const mtimes: LayerMtimes = new Map<string, string | number>([
+			const mtimes: LayerMtimes = new Map([
 				['sha256:img1', 0],
 				[digest, recentTime],
 			]);
@@ -178,12 +176,12 @@ describe('createTree', function () {
 		});
 
 		it('should prefer most recent mtime when ID and tag are both non-zero', function () {
-			const idTime = 1700000000000000000;
-			const tagTime = 1600000000000000000;
+			const idTime = 1700000000;
+			const tagTime = 1600000000;
 			const images: ImageInfo[] = [
 				makeImage('sha256:img1', '', { tags: ['myapp:latest'] }),
 			];
-			const mtimes: LayerMtimes = new Map<string, string | number>([
+			const mtimes: LayerMtimes = new Map([
 				['sha256:img1', idTime],
 				['myapp:latest', tagTime],
 			]);
@@ -203,7 +201,7 @@ describe('createTree', function () {
 			const tree = createTree(images, [], new Map());
 			tk.reset();
 
-			const expectedNow = FROZEN_DATE * 1e6;
+			const expectedNow = Math.floor(FROZEN_DATE / 1000);
 			expect(tree.children['sha256:new-image'].mtime).to.equal(expectedNow);
 		});
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -25,9 +25,17 @@ const promiseToBool = async (p: Promise<unknown>): Promise<boolean> => {
 	}
 };
 
+const registryAuth =
+	process.env.DOCKERHUB_USER && process.env.DOCKERHUB_TOKEN
+		? {
+				username: process.env.DOCKERHUB_USER,
+				password: process.env.DOCKERHUB_TOKEN,
+			}
+		: undefined;
+
 const pullAsync = async function (d: Docker, tag: string) {
 	console.log(`[TEST] Pulling ${tag}`);
-	const stream = await d.pull(tag);
+	const stream = await d.pull(tag, { authconfig: registryAuth });
 	return await new Promise(function (resolve, reject) {
 		stream.resume();
 		stream.once('error', reject);
@@ -222,6 +230,58 @@ describe('Garbage collection', function () {
 			expect(imageInspect).to.be.true;
 		} finally {
 			await docker.getContainer(containerName).stop();
+		}
+	});
+
+	it('should not delete an image created by tag when mtime was recorded under tag key', async function () {
+		if (SKIP_GC_TEST) {
+			return;
+		}
+		this.timeout(600000);
+		const containerName = 'tag-mtime-test';
+
+		// Pull the target image, then create a FRESH DockerGC instance.
+		// The fresh instance has empty currentMtimes, so setupMtimeStream
+		// calls parseEventStream which sees alpine already present and
+		// initializes its ID key to mtime=0 ("known but old").
+		await pullAsync(docker, IMAGES[0]);
+		dockerStorage.destroyMtimeStream();
+		dockerStorage = new DockerGC();
+		await dockerStorage.setDocker(DOCKER_OPTS);
+		await dockerStorage.setupMtimeStream();
+
+		// Pull the sacrificial image first — its pull event gives it an
+		// ID-keyed mtime that is older than the container events below.
+		try {
+			await pullAsync(docker, IMAGES[1]);
+
+			// Create+destroy a container from target by TAG. The container
+			// events store mtime under the tag key ("alpine:3.18"), NOT
+			// the sha256 ID key. Without the getMtime fix, the ID key (0)
+			// shadows the tag key and the image appears stale.
+			const container = await docker.createContainer({
+				Image: IMAGES[0],
+				Cmd: ['true'],
+				name: containerName,
+			});
+			await container.start();
+			await container.wait();
+			await container.remove();
+
+			await dockerStorage.garbageCollect(1);
+
+			// Without fix: target mtime resolves to 0 (ID key) → deleted
+			// With fix: target mtime resolves to container destroy time (tag key) → survives
+			const targetImageExists = await promiseToBool(
+				docker.getImage(IMAGES[0]).inspect(),
+			);
+			expect(targetImageExists).to.be.true;
+		} finally {
+			try {
+				await docker.getContainer(containerName).remove({ force: true });
+			} catch {
+				// ignore
+			}
 		}
 	});
 

--- a/test/lib/common.ts
+++ b/test/lib/common.ts
@@ -1,4 +1,5 @@
 import type Docker from 'dockerode';
+import type { ContainerInfo, ImageInfo } from 'dockerode';
 import { getDocker } from '../../build/docker';
 
 function parseDockerHost(): Docker.DockerOptions {
@@ -16,3 +17,23 @@ function parseDockerHost(): Docker.DockerOptions {
 export const DOCKER_OPTS = parseDockerHost();
 
 export const docker = getDocker(DOCKER_OPTS);
+
+export const makeImage = (
+	id: string,
+	parentId: string,
+	opts: { tags?: string[]; digests?: string[]; size?: number } = {},
+): ImageInfo => ({
+	Id: id,
+	ParentId: parentId,
+	RepoTags: opts.tags ?? ['<none>:<none>'],
+	RepoDigests: opts.digests ?? ['<none>@<none>'],
+	Size: opts.size ?? 100000,
+	VirtualSize: opts.size ?? 100000,
+	SharedSize: 0,
+	Containers: 0,
+	Created: 0,
+	Labels: {},
+});
+
+export const makeContainer = (imageId: string): ContainerInfo =>
+	({ ImageID: imageId }) as unknown as ContainerInfo;


### PR DESCRIPTION
getMtime used nullish coalescing (??) to fall through from ID to tag
to digest lookup. But parseEventStream initializes all image IDs to
mtime=0, and 0 is not nullish. Container events with from=tag store
mtime under the tag key, but getMtime found 0 under the ID key first
and returned it — silently discarding the more recent tag-keyed value.

Fix by collecting mtime candidates from all keys (ID, tags, digests)
and returning the maximum (most recent) value. This ensures container
events recorded under any key format are correctly reflected.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/194