### PR TITLE
Add markUsed method to manually refresh mtime value

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -183,6 +183,15 @@ export default class DockerGC {
 		});
 	}
 
+	// Refresh the mtime of one or more image references (tag, digest, or ID)
+	// so they are not treated as stale by the next GC run.
+	public markUsed(...refs: string[]): void {
+		const now = Math.floor(Date.now() / 1000);
+		for (const ref of refs) {
+			this.currentMtimes.set(ref, now);
+		}
+	}
+
 	public destroyMtimeStream(): void {
 		if (this.mtimeStream != null) {
 			this.mtimeStream.removeAllListeners();

--- a/test/index.ts
+++ b/test/index.ts
@@ -285,6 +285,31 @@ describe('Garbage collection', function () {
 		}
 	});
 
+	it('should protect a marked-used image from GC', async function () {
+		this.timeout(600000);
+		if (SKIP_GC_TEST) {
+			return;
+		}
+
+		// Pull two images so GC has something to remove
+		await Promise.all([
+			pullAsync(docker, IMAGES[0]),
+			pullAsync(docker, IMAGES[1]),
+		]);
+
+		// Mark one of them as used and run GC
+		dockerStorage.markUsed(IMAGES[0]);
+		await dockerStorage.garbageCollect(1);
+
+		// Assert the marked image was not removed
+		const [markedExists, unmarkedExists] = await Promise.all([
+			promiseToBool(docker.getImage(IMAGES[0]).inspect()),
+			promiseToBool(docker.getImage(IMAGES[1]).inspect()),
+		]);
+		expect(markedExists).to.be.true;
+		expect(unmarkedExists).to.be.false;
+	});
+
 	it('should get daemon host disk usage', async function () {
 		this.timeout(600000);
 		const du = await dockerStorage.getDaemonFreeSpace();


### PR DESCRIPTION
We update mtimes using events emitted by Docker, but
that might not always be enough. This new method allows
consumers to directly update ref mtimes to now so they
aren't removed by GC.

Change-type: minor

---

Untested WIP that may not be necessary, built on the assumption that the change to BuildKit with moby v23 is causing less docker events resulting in our mtimes not being updated as often as it was before.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/194