### PR TITLE
Treat 409 conflict errors as noop during image removal

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -229,6 +229,12 @@ export default class DockerGC {
 							);
 							continue;
 						}
+						if (e.statusCode === 409) {
+							console.log(
+								`[GC (${this.host}] Image has dependent children, skipping: ${attribute} (id: ${image.id})`,
+							);
+							continue;
+						}
 						throw e;
 					}
 					this.metrics.emit('imageRemoved', removalType);


### PR DESCRIPTION
- Skip 409 (conflict) errors during image removal, same as existing 404 handling
- The engine refuses deletion when an image has dependent child images at the layer level, even though our tree considers it removable

## Why this started happening

PR #76 fixed the cascading deletion ordering so that parent images correctly become candidates when all their children are removed. Before that fix, GC only deleted leaf nodes and never attempted to delete intermediates.

With cascading working, GC now walks up parent chains and tries to delete intermediate build images. These intermediates often share layers with other build chains. The engine protects shared layers by refusing deletion with 409, but our `ParentId`-based tree doesn't model layer-level sharing so it can't predict which images the engine will refuse.

## Details

The GC image tree is built from `ParentId` which tracks build-step ancestry. The engine also tracks layer-level dependencies (shared overlay2 layers between unrelated images) that `ParentId` doesn't capture. When GC selects an image our tree considers removable, the engine may refuse with 409 because another image shares its layers.

With `attemptAll=true`, these 409 errors accumulate without reclaiming space, causing GC to re-trigger on every build cycle. Treating 409 as a noop lets GC skip undeletable images and continue reclaiming from images it can actually remove.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/194