### PR TITLE
Use Size - SharedSize for reclaim accounting

### DIFF
--- a/lib/docker-image-tree.ts
+++ b/lib/docker-image-tree.ts
@@ -18,6 +18,8 @@ const saneRepoAttrs = function (repoAttrs: string[] | undefined) {
 export const createNode = (id: string): ImageNode => ({
 	id,
 	size: 0,
+	sharedSize: 0,
+	uniqueSize: 0,
 	repoTags: [],
 	repoDigests: [],
 	mtime: 0,
@@ -43,6 +45,15 @@ const getMtime = function (tree: ImageNode, layerMtimes: LayerMtimes) {
 export interface ImageNode {
 	id: string;
 	size: number;
+	/**
+	 * Size of layers shared with other images, as reported by the engine when
+	 * listImages is called with `shared-size=1`. The unique on-disk contribution
+	 * of this image is `size - sharedSize`. Defaults to 0 if the engine did not
+	 * report it (older engines, or the option was not requested).
+	 */
+	sharedSize: number;
+	/** `Math.max(0, size - sharedSize)` — precomputed to avoid repeated calculation during sort. */
+	uniqueSize: number;
 	repoTags: string[];
 	repoDigests: string[];
 	mtime: NonNullable<LayerMtimes extends Map<any, infer U> ? U : never>;
@@ -71,6 +82,11 @@ export const createTree = function (
 		node.repoTags = saneRepoAttrs(image.RepoTags);
 		node.repoDigests = saneRepoAttrs(image.RepoDigests);
 		node.size = image.Size;
+		// Engines that don't implement shared-size return -1. Treat that as 0
+		// so we fall back to counting the full chain size (pre-shared-size
+		// behaviour) rather than silently inflating reclaim estimates.
+		node.sharedSize = image.SharedSize >= 0 ? image.SharedSize : 0;
+		node.uniqueSize = Math.max(0, node.size - node.sharedSize);
 		// If we haven't seen the image at all then assume it is brand new and default it's
 		// mtime to `now` to avoid removing it
 		node.mtime = getMtime(node, layerMtimes) ?? now;
@@ -88,7 +104,15 @@ export async function dockerImageTree(
 	layerMtimes: LayerMtimes,
 ) {
 	const [images, containers] = await Promise.all([
-		docker.listImages({ all: true }),
+		// `shared-size` asks the engine to populate ImageInfo.SharedSize so we
+		// can subtract it from Size when computing reclaimable space. Without
+		// this, every shared layer is counted once per image that references
+		// it, inflating reclaim estimates by 10-20x on builder workers.
+		docker.listImages({
+			all: true,
+			// @ts-expect-error `shared-size` works but isn't in dockerode's typings yet
+			'shared-size': true,
+		} satisfies Docker.ListImagesOptions as Docker.ListImagesOptions),
 		docker.listContainers({ all: true }),
 	]);
 	return createTree(images, containers, layerMtimes);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -54,7 +54,10 @@ const sortBy = <T extends object>(key: keyof T): ((a: T, b: T) => number) => {
 	return (a, b) => (a[key] > b[key] ? 1 : b[key] > a[key] ? -1 : 0);
 };
 const mtimeSort = sortBy('mtime');
-const sizeSort = sortBy('size');
+// Sort by the reclaimable (unique) bytes of each image, not the full chain
+// size. Prioritising full chain size would pop images whose removal frees
+// almost nothing because all their layers are shared with other images.
+const uniqueSizeSort = sortBy('uniqueSize');
 
 /**
  * This will mutate the passed in tree, marking the images to be removed as removed.
@@ -72,8 +75,9 @@ const getImagesToRemove = function (
 	const leafs = getUnusedTreeLeafs(tree);
 	const resort = () => {
 		leafs.sort((a, b) => {
-			// mtime desc, size asc
-			return -mtimeSort(a, b) || sizeSort(a, b);
+			// mtime desc, unique-size asc — pop() removes from the end, so
+			// oldest+largest-unique gets evicted first.
+			return -mtimeSort(a, b) || uniqueSizeSort(a, b);
 		});
 	};
 	resort();
@@ -86,7 +90,15 @@ const getImagesToRemove = function (
 		if (leaf !== tree) {
 			// don't remove the tree root
 			result.push(leaf);
-			size += leaf.size;
+			// Credit only the layers unique to this image. The engine reports
+			// `size` as the sum of every layer in the image's chain, including
+			// layers shared with other images on disk. Summing raw `size`
+			// across removals over-counts shared layers and makes GC think it
+			// reclaimed far more than it did. `size - sharedSize` is a
+			// conservative floor on the actual reclaim; if cascading removals
+			// also drop the last reference to a shared layer, the extra
+			// reclaim is accounted for when that image is popped in turn.
+			size += leaf.uniqueSize;
 			if (leaf.parent != null && isCandidateForRemoval(leaf.parent)) {
 				// If the parent is now a candidate for deletion then add to the potential leafs and resort them
 				leafs.push(leaf.parent);
@@ -218,7 +230,7 @@ export default class DockerGC {
 			return (async () => {
 				for (const attribute of attributes) {
 					console.log(
-						`[GC (${this.host}] Removing image : ${attribute} (id: ${image.id}, size: ${image.size}, mtime: ${image.mtime})`,
+						`[GC (${this.host}] Removing image : ${attribute} (id: ${image.id}, size: ${image.size}, sharedSize: ${image.sharedSize}, mtime: ${image.mtime})`,
 					);
 					try {
 						await this.docker.getImage(attribute).remove({ noprune: true });

--- a/test/docker-image-tree.ts
+++ b/test/docker-image-tree.ts
@@ -51,6 +51,8 @@ describe('createTree', function () {
 		const output = {
 			id: '0000000000000000000000000000000000000000000000000000000000000000',
 			size: 0,
+			sharedSize: 0,
+			uniqueSize: 0,
 			repoTags: [],
 			repoDigests: [],
 			mtime: 1451606400,
@@ -60,6 +62,8 @@ describe('createTree', function () {
 					{
 						id: 'sha256:6d15899cef812e2876b9d5d43d4cd863eda7b278f7b52d00975f6a9a8e817c74',
 						size: 125151141,
+						sharedSize: 0,
+						uniqueSize: 125151141,
 						repoTags: [],
 						repoDigests: [],
 						mtime: 1451606400,
@@ -69,6 +73,8 @@ describe('createTree', function () {
 								{
 									id: 'sha256:e53bd4df04f86919156c4510cdc6e6c9491ec8ec226381d36aca573b46bbbbbc',
 									size: 0,
+									sharedSize: 0,
+									uniqueSize: 0,
 									repoTags: ['project1'],
 									repoDigests: [],
 									mtime: 1451606400,
@@ -78,6 +84,8 @@ describe('createTree', function () {
 											{
 												id: 'sha256:6d41a4a0bf8168363e29da8a5ecbf3cd6c37e3f5a043decd5e7da6e427ba869c',
 												size: 330389,
+												sharedSize: 0,
+												uniqueSize: 330389,
 												repoTags: ['project2'],
 												repoDigests: [],
 												mtime: 1448576073,
@@ -87,6 +95,8 @@ describe('createTree', function () {
 														{
 															id: 'sha256:80dc79d29cd8618e678da508fc32f7289e6f72defb534f3f287731b1f8b355ea',
 															size: 98872,
+															sharedSize: 0,
+															uniqueSize: 98872,
 															repoTags: [],
 															repoDigests: [],
 															mtime: 1451606400,
@@ -103,6 +113,8 @@ describe('createTree', function () {
 					{
 						id: 'sha256:902b87aaaec929e80541486828959f14fa061f529ad7f37ab300d4ef9f3a0dbf',
 						size: 125151141,
+						sharedSize: 0,
+						uniqueSize: 125151141,
 						repoTags: [],
 						repoDigests: [],
 						mtime: 1451606400,
@@ -112,6 +124,8 @@ describe('createTree', function () {
 								{
 									id: 'sha256:9a61b6b1315e6b457c31a03346ab94486a2f5397f4a82219bee01eead1c34c2e',
 									size: 0,
+									sharedSize: 0,
+									uniqueSize: 0,
 									repoTags: ['resin/project3'],
 									repoDigests: [],
 									mtime: 1448576073,
@@ -124,6 +138,8 @@ describe('createTree', function () {
 					{
 						id: 'sha256:5b0d59026729b68570d99bc4f3f7c31a2e4f2a5736435641565d93e7c25bd2c3',
 						size: 125151141,
+						sharedSize: 0,
+						uniqueSize: 125151141,
 						repoTags: ['busybox:latest'],
 						repoDigests: [
 							'sha256:a8cf7ff6367c2afa2a90acd081b484cbded349a7076e7bdf37a05279f276bc12',
@@ -216,6 +232,75 @@ describe('createTree', function () {
 			tk.reset();
 
 			expect(tree.children['sha256:old'].mtime).to.equal(0);
+		});
+	});
+
+	describe('sharedSize and uniqueSize', function () {
+		it('should compute uniqueSize from SharedSize', function () {
+			const images: ImageInfo[] = [
+				makeImage('sha256:img1', '', {
+					tags: ['app:latest'],
+					size: 500000,
+					sharedSize: 400000,
+				}),
+			];
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], new Map());
+			tk.reset();
+
+			const node = tree.children['sha256:img1'];
+			expect(node.size).to.equal(500000);
+			expect(node.sharedSize).to.equal(400000);
+			expect(node.uniqueSize).to.equal(100000);
+		});
+
+		it('should treat negative SharedSize as 0', function () {
+			const images: ImageInfo[] = [
+				makeImage('sha256:img1', '', {
+					tags: ['app:latest'],
+					size: 500000,
+					sharedSize: -1,
+				}),
+			];
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], new Map());
+			tk.reset();
+
+			const node = tree.children['sha256:img1'];
+			expect(node.sharedSize).to.equal(0);
+			expect(node.uniqueSize).to.equal(500000);
+		});
+
+		it('should default SharedSize 0 when not provided', function () {
+			const images: ImageInfo[] = [
+				makeImage('sha256:img1', '', {
+					tags: ['app:latest'],
+					size: 300000,
+				}),
+			];
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], new Map());
+			tk.reset();
+
+			const node = tree.children['sha256:img1'];
+			expect(node.sharedSize).to.equal(0);
+			expect(node.uniqueSize).to.equal(300000);
+		});
+
+		it('should clamp uniqueSize to 0 when sharedSize exceeds size', function () {
+			const images: ImageInfo[] = [
+				makeImage('sha256:img1', '', {
+					tags: ['app:latest'],
+					size: 100000,
+					sharedSize: 200000,
+				}),
+			];
+			tk.freeze(FROZEN_DATE);
+			const tree = createTree(images, [], new Map());
+			tk.reset();
+
+			const node = tree.children['sha256:img1'];
+			expect(node.uniqueSize).to.equal(0);
 		});
 	});
 

--- a/test/lib/common.ts
+++ b/test/lib/common.ts
@@ -21,7 +21,12 @@ export const docker = getDocker(DOCKER_OPTS);
 export const makeImage = (
 	id: string,
 	parentId: string,
-	opts: { tags?: string[]; digests?: string[]; size?: number } = {},
+	opts: {
+		tags?: string[];
+		digests?: string[];
+		size?: number;
+		sharedSize?: number;
+	} = {},
 ): ImageInfo => ({
 	Id: id,
 	ParentId: parentId,
@@ -29,7 +34,7 @@ export const makeImage = (
 	RepoDigests: opts.digests ?? ['<none>@<none>'],
 	Size: opts.size ?? 100000,
 	VirtualSize: opts.size ?? 100000,
-	SharedSize: 0,
+	SharedSize: opts.sharedSize ?? 0,
 	Containers: 0,
 	Created: 0,
 	Labels: {},


### PR DESCRIPTION
`getImagesToRemove` sums `ImageInfo.Size` to decide when enough bytes are queued for reclaim. But `Size` is the full chain size — every layer in an image's ancestry is counted, including layers shared with other images on disk. This massively over-counts on builder workers.

Measured on a production arm64 builder worker (`a8df1a3.builders.balena.io:2377`) during incident [#194](https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/194):

| Metric | Value |
|---|---|
| Image count (`?all=1&shared-size=1`) | 51,836 |
| Sum of `Size` (what GC sees today) | 33.84 TB |
| Sum of `SharedSize` | 33.08 TB (97.8% shared) |
| Sum of `Size - SharedSize` | 0.755 TB |
| Engine-deduped actual (`system df`) | 2.245 TB |
| Partition used (`df`) | 2.57 TB |

So GC's per-image reclaim credit was overstated by ~15x vs actual on-disk usage. GC hits its target after credits that reflect only a fraction of the bytes it claimed to reclaim; `df` stays high; GC runs again on the next build; eventually reaches and removes images a concurrent build still needs → 404.

`Size - SharedSize` is a conservative **floor**: it's the bytes freed if this image alone is removed and all its shared layers stay. If cascading removals also drop the last reference to a formerly-shared layer, that extra reclaim gets credited when the next image is popped (its `sharedSize` will reflect fewer references).

Older engines that don't implement `shared-size` return `SharedSize: -1`; we treat that as 0 so we fall back to the pre-change behaviour rather than silently under-counting.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/194
